### PR TITLE
Improve Gitpod setup to plot charts graphically

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,4 @@
-image:
-  file: Dockerfile
+image: gitpod/workspace-full-vnc:branch-jx-python-tk
 github:
   prebuilds:
     # enable for the master/default branch (defaults to true)
@@ -18,6 +17,9 @@ github:
     addLabel: prebuilt-in-gitpod
 tasks:
 - command: bash setup_pycalc.sh
+ports:
+  - port: 6080
+    onOpen: open-preview
 vscode:
   extensions:
     - almenon.arepl@1.0.16:XGYMBgfBMAnJXoyFkfSzPA==

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM gitpod/workspace-full-vnc
-USER root
-RUN mkdir /app
-WORKDIR /app
-ADD . /app
-RUN python3 setup.py install

--- a/algeb/graph/graphQuadMod.py
+++ b/algeb/graph/graphQuadMod.py
@@ -1,5 +1,7 @@
 import numpy as np
 import numpy
+import matplotlib
+matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 import matplotlib.axis
 from sympy import *


### PR DESCRIPTION
Hi @JesterOrNot!

In this Pull Request, I've made the following changes:

- Replace Dockerfile with a core image where Python3 works with Tk (the image was built from https://github.com/gitpod-io/workspace-images/pull/119, which I hope to merge soon, so eventually you'll be able to use the default `gitpod/workspace-full-vnc` image instead)
- Pre-expose port 6080, which is Gitpod's Virtual Desktop, and automatically open it in a side panel
- Configure Matplotlib in `graphQuadMod.py` to use `TkAgg` instead of `agg`, thus displaying plots in graphical windows

It should look like this:

<img width="1552" alt="Screenshot 2019-10-01 at 16 37 02" src="https://user-images.githubusercontent.com/599268/65973201-3565ac00-e46b-11e9-978c-7cd10d29e0b4.png">

This isn't perfect however:

- The Virtual Desktop (noVNC) side panel now always opens, even when you only want to do command-line calculations. Ideally it should only open when you do some graphical stuff, but we have no way to detect that yet (you can control the preview manually though, by using `onOpen: ignore` and running a command like `gp preview $(gp url 6080)` when the preview is appropriate)
- The noVNC connection is a little bit unstable. Sometimes you need to refresh the preview, and other times (if the port 6080 server crashes) you'll need to open a new Terminal, because the noVNC auto-restarting script lives in `~/.bashrc`
- By default, you only see a small part of the Virtual Desktop, the being hidden. And since Matplotlib will open a graphical window in the center of the screen, you need to scroll a bit in the Virtual Desktop to find the window. Maybe there is a way to change or auto-adjust noVNC's screen dimensions, or to make Matplotlib open windows in the screen's top left

Please let me know what you think, or if I should change anything here. 🙂 I'm happy to make as many iterations as necessary.